### PR TITLE
Fix page titles

### DIFF
--- a/layout/partials/head.ejs
+++ b/layout/partials/head.ejs
@@ -11,7 +11,8 @@
   if (is_category()) pageTitle = 'Category: ' + page.category;
   if (is_month()) pageTitle += ': ' + page.month + '/' + page.year;
   if (is_year()) pageTitle += ': ' + page.year;
-  pageTitle += ' [ ' + config.title + ' ]';
+  if (pageTitle.length > 0) pageTitle += ' - ';
+  pageTitle += config.title;
   %>
   <title><%=pageTitle%></title>
   <% if (theme.stylesheets !== undefined && theme.stylesheets.length > 0) { %>


### PR DESCRIPTION
Fix page titles to conditionally concatenate a separator, and get rid of the static space in the Home title.

### Before
Home Title = ```<title> [ Blog Name ]</title>``` (Notice the space at the beginning)
Post Title = ```<title>Example Post [ Blog Name ]</title>```

### After
Home Title = ```<title>Blog Name</title>``` (Space is gone 👍)
Post Title = ```<title>Example Post - Blog Name</title>```